### PR TITLE
Include Python modules in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,8 @@ include CONTRIBUTORS.txt
 # include only files in docs, not subdirs like _build
 include docs/*
 include imgs/*
+# Explicitly include all Python modules so new files are picked up
+recursive-include sourcespec *.py
 # exclude configuration_file.rst, which is generated when
 # building docs
 exclude docs/configuration_file.rst


### PR DESCRIPTION
## Summary
- ensure the sdist explicitly bundles Python modules by recursively including sourcespec *.py in MANIFEST.in

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cdcde8dda88333bb11269065640292