### PR TITLE
Handle string spectral SNR mask threshold

### DIFF
--- a/sourcespec/ssp_build_spectra.py
+++ b/sourcespec/ssp_build_spectra.py
@@ -877,6 +877,16 @@ def _build_signal_and_noise_spectral_streams(
         try:
             # Optional low-frequency SNR mask *prior to smoothing*:
             th = getattr(config, 'spectral_snr_mask_threshold', None)
+            if isinstance(th, str):
+                try:
+                    th = float(th)
+                except ValueError:
+                    logger.warning(
+                        'Invalid spectral SNR mask threshold %r: disabling mask',
+                        th)
+                    th = None
+                else:
+                    setattr(config, 'spectral_snr_mask_threshold', th)
             use_mask = th is not None and th > 0
             if use_mask:
                 # Build spectra up to (but not including) smoothing


### PR DESCRIPTION
## Summary
- coerce the spectral SNR mask threshold configuration value to float when provided as a string
- disable the mask gracefully when the threshold cannot be interpreted as a number

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d178c006388333a70c22b021b2e7a0