### PR TITLE
Apply SNR mask using RSS spectrum and plot event moment

### DIFF
--- a/sourcespec/ssp_build_spectra.py
+++ b/sourcespec/ssp_build_spectra.py
@@ -517,6 +517,102 @@ def _pre_smoothing_snr_mask(config, spec, specnoise):
         spec.stats.snr_mask_info = mask_info
 
 
+def _apply_mask_info_to_component(spec, mask_info):
+    """Apply RSS-derived mask information to a single component spectrum."""
+    if not mask_info:
+        return
+    # Store a copy of the mask info so later consumers (plots) can reuse it.
+    spec.stats.snr_mask_info = dict(mask_info)
+    if not mask_info.get('applied'):
+        return
+    mode = mask_info.get('mode', 'left_of_first')
+    freq = spec.freq
+    data = spec.data
+    if mode == 'left_of_first':
+        f_cross = mask_info.get('f_cross')
+        if not f_cross:
+            return
+        ramp_dec = float(mask_info.get('ramp_decades', 0.0) or 0.0)
+        eps = np.finfo(float).eps
+        idx_candidates = np.where(freq >= f_cross)[0]
+        if not idx_candidates.size:
+            return
+        idx = idx_candidates[0]
+        A0 = data[idx]
+        left = np.where(freq < f_cross)[0]
+        if left.size:
+            data[left] = np.minimum(data[left], A0)
+        if ramp_dec > 0.0:
+            f_ramp_start = mask_info.get('f_ramp_start')
+            if f_ramp_start is None:
+                f_ramp_start = f_cross / (10.0 ** ramp_dec)
+            if f_ramp_start < f_cross:
+                band = np.where((freq >= f_ramp_start) & (freq < f_cross))[0]
+                if band.size:
+                    x = (freq[band] - f_ramp_start) / max(f_cross - f_ramp_start, eps)
+                    w = 0.5 * (1.0 - np.cos(np.pi * x))
+                    data[band] = np.minimum(data[band], A0 * w + data[band] * (1.0 - w))
+        spec.data = data
+    else:
+        freq_min = mask_info.get('freq_min')
+        freq_max = mask_info.get('freq_max')
+        if freq_min is None or freq_max is None:
+            return
+        mask = (freq >= freq_min) & (freq <= freq_max)
+        if np.any(mask):
+            unmasked = np.where(~mask)[0]
+            A0 = np.min(data[unmasked]) if unmasked.size else np.min(data)
+            data[mask] = np.minimum(data[mask], A0)
+            spec.data = data
+
+
+def _apply_rss_snr_mask(config, spec_st, specnoise_st):
+    """Apply the spectral SNR mask using the root sum of squares spectrum."""
+    if not spec_st:
+        return
+    spec_ids = {sp.id[:-1] for sp in spec_st}
+    vertical_codes = config.vertical_channel_codes
+    wave_type = config.wave_type
+    for specid in spec_ids:
+        spec_sel = _select_spectra(spec_st, specid)
+        if specnoise_st:
+            specnoise_sel = _select_spectra(specnoise_st, specid)
+        else:
+            specnoise_sel = SpectrumStream()
+        codes = {sp.stats.channel[:-1] for sp in spec_sel}
+        for code in codes:
+            components = SpectrumStream(
+                sp for sp in spec_sel
+                if sp.stats.channel[:-1] == code and
+                sp.stats.channel[-1] not in ['H', 'h', 'S', 's', 't']
+            )
+            if not components:
+                continue
+            noises = SpectrumStream(
+                sp for sp in specnoise_sel
+                if sp.stats.channel[:-1] == code and
+                sp.stats.channel[-1] not in ['H', 'h', 'S', 's', 't']
+            )
+            spec_h = _compute_spec_h(
+                components, code, vertical_codes, wave_type)
+            if spec_h is None or getattr(spec_h.stats, 'ignore', False):
+                continue
+            specnoise_h = _compute_spec_h(
+                noises, code, vertical_codes, wave_type)
+            if specnoise_h is None:
+                continue
+            _pre_smoothing_snr_mask(config, spec_h, specnoise_h)
+            mask_info = getattr(spec_h.stats, 'snr_mask_info', None)
+            if not mask_info:
+                continue
+            mask_info = dict(mask_info)
+            mask_info['source_channel'] = spec_h.stats.channel
+            for component in components:
+                if getattr(component.stats, 'ignore', False):
+                    continue
+                _apply_mask_info_to_component(component, mask_info)
+
+
 def _smooth_spectrum(spec, smooth_width_decades=0.2):
     """
     Smooth spectrum in a log10-freq space.
@@ -894,49 +990,57 @@ def _build_signal_and_noise_spectral_streams(
     """
     spec_st = SpectrumStream()
     specnoise_st = SpectrumStream()
+    spec_items = []
+
+    th = getattr(config, 'spectral_snr_mask_threshold', None)
+    if isinstance(th, str):
+        try:
+            th = float(th)
+        except ValueError:
+            logger.warning(
+                'Invalid spectral SNR mask threshold %r: disabling mask',
+                th)
+            th = None
+        else:
+            setattr(config, 'spectral_snr_mask_threshold', th)
+    use_mask = th is not None and th > 0
+
     for trace_signal in sorted(signal_st, key=lambda tr: tr.id):
         trace_noise = noise_st.select(id=trace_signal.id)[0]
         try:
-            # Optional low-frequency SNR mask *prior to smoothing*:
-            th = getattr(config, 'spectral_snr_mask_threshold', None)
-            if isinstance(th, str):
-                try:
-                    th = float(th)
-                except ValueError:
-                    logger.warning(
-                        'Invalid spectral SNR mask threshold %r: disabling mask',
-                        th)
-                    th = None
-                else:
-                    setattr(config, 'spectral_snr_mask_threshold', th)
-            use_mask = th is not None and th > 0
-            if use_mask:
-                # Build spectra up to (but not including) smoothing
-                spec = _build_spectrum(config, trace_signal, do_smooth=False)
-                specnoise = _build_spectrum(config, trace_noise, do_smooth=False)
-                # Apply the mask before smoothing to avoid bleed into log-smoothing
-                _pre_smoothing_snr_mask(config, spec, specnoise)
-                # Now smooth (this creates log-spaced arrays used downstream)
-                _smooth_spectrum(spec, config.spectral_smooth_width_decades)
-                _smooth_spectrum(specnoise, config.spectral_smooth_width_decades)
-            else:
-                # Default behavior (no mask)
-                spec = _build_spectrum(config, trace_signal)
-                specnoise = _build_spectrum(config, trace_noise)
-            _check_spectral_sn_ratio(config, spec, specnoise)
+            spec = _build_spectrum(
+                config, trace_signal, do_smooth=not use_mask)
+            specnoise = _build_spectrum(
+                config, trace_noise, do_smooth=not use_mask)
         except RuntimeError as msg:
-            # RuntimeError is for skipped spectra
             logger.warning(msg)
             continue
+        spec_items.append((spec, specnoise, trace_signal))
+        spec_st.append(spec)
+        specnoise_st.append(specnoise)
+
+    if not spec_st:
+        logger.error('No spectra left! Exiting.')
+        ssp_exit()
+
+    if use_mask:
+        # Apply the mask on root-sum-of-squares spectra before smoothing.
+        _apply_rss_snr_mask(config, spec_st, specnoise_st)
+        for spec in spec_st:
+            _smooth_spectrum(spec, config.spectral_smooth_width_decades)
+        for specnoise in specnoise_st:
+            _smooth_spectrum(specnoise, config.spectral_smooth_width_decades)
+
+    for spec, specnoise, trace_signal in spec_items:
+        try:
+            _check_spectral_sn_ratio(config, spec, specnoise)
         except SpectrumIgnored as msg:
             _ignore_spectrum(msg, spec, specnoise)
             trace_original = original_st.select(id=trace_signal.id)[0]
             _ignore_trace(msg, trace_original)
-        spec_st.append(spec)
-        specnoise_st.append(specnoise)
-    if not spec_st:
-        logger.error('No spectra left! Exiting.')
-        ssp_exit()
+        except RuntimeError as msg:
+            logger.warning(msg)
+
     # build H component
     _build_H(
         spec_st, specnoise_st, config.vertical_channel_codes, config.wave_type)

--- a/sourcespec/ssp_plot_spectra.py
+++ b/sourcespec/ssp_plot_spectra.py
@@ -651,6 +651,30 @@ def _plot_snr_mask_indicator(spec, ax):
             f_ramp_start, f_cross, color='#CC9933', alpha=0.12, zorder=2)
 
 
+def _plot_event_moment_line(spec, ax, ax2):
+    """Plot the catalog/event seismic moment as a reference line."""
+    if getattr(ax, '_event_moment_drawn', False):
+        return
+    event = getattr(spec.stats, 'event', None)
+    if not event:
+        return
+    scalar_moment = getattr(getattr(event, 'scalar_moment', None), 'value', None)
+    if scalar_moment is None or scalar_moment <= 0:
+        return
+    color = '#555555'
+    ax.axhline(
+        scalar_moment, color=color, linestyle='--', linewidth=1.5, zorder=4)
+    ax._event_moment_drawn = True  # pylint: disable=protected-access
+    if ax2 and not getattr(ax2, '_event_moment_drawn', False):
+        try:
+            Mw = float(moment_to_mag(scalar_moment))
+        except (TypeError, ValueError):
+            return
+        ax2.axhline(
+            Mw, color=color, linestyle='--', linewidth=1.0, zorder=4)
+        ax2._event_moment_drawn = True  # pylint: disable=protected-access
+
+
 def _plot_spec(config, plot_params, spec, spec_noise):
     """Plot one spectrum (and its associated noise)."""
     plotn = plot_params.plotn
@@ -686,6 +710,7 @@ def _plot_spec(config, plot_params, spec, spec_noise):
         if orientation == 'S':
             _plot_fc_and_mw(spec, ax, ax2)
         _plot_snr_mask_indicator(spec, ax)
+        _plot_event_moment_line(spec, ax, ax2)
     elif plot_type == 'weight':
         ax.semilogx(
             spec.freq, spec.data, color=color, alpha=alpha, zorder=20)


### PR DESCRIPTION
## Summary
- apply the low-frequency SNR mask on the root-sum-of-squares spectrum and propagate the resulting limits to each component before smoothing
- refactor spectrum-building flow so masking happens before smoothing, while still running S/N checks afterward
- draw the catalog seismic moment (and equivalent magnitude) as a horizontal reference line on spectra plots

## Testing
- python -m compileall sourcespec

------
https://chatgpt.com/codex/tasks/task_b_68d1836cf0b48333a11ce19d241f77da